### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ XamAR.WorldForms.Init(this, savedInstanceState);
 
 global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
 ```
+- Using nuget add Xamarin.Google.ARCore
 - In project properties set minimum version 28 and target version 30
 - Next, open *AndroidManifest.xml* and set permissions:
     


### PR DESCRIPTION
Seems not to work unless Xamarin.Google.ARCore library is referenced by client Android project 
(without it, program notifies about ARCore requiring latest "Google Play Services for AR", and despite having latest version, it shows error  "Failed to create AR session" and black ARView control).